### PR TITLE
Fixes train_test table formating.

### DIFF
--- a/revscoring/utilities/train_test.py
+++ b/revscoring/utilities/train_test.py
@@ -115,23 +115,30 @@ def run(feature_labels, model_file, scorer_model):
     scorer_model.train(train_set)
 
     stats = scorer_model.test(test_set)
+
+    possible = list(set(actual for _, actual in stats['table'].keys()))
+    possible.sort()
+
     sys.stderr.write("Accuracy: {0}\n\n".format(stats['accuracy']))
     if 'auc' in stats['roc']:
-        sys.stderr.write("ROC-AUC: {0}\n".format(stats['roc']['auc']))
+        sys.stderr.write("ROC-AUC: {0}\n\n".format(stats['roc']['auc']))
     else:
         sys.stderr.write("ROC-AUC:\n")
 
+
         table_data = [[comparison_label, stats['roc'][comparison_label]['auc']]
-                      for comparison_label in stats['roc']]
+                      for comparison_label in possible]
         sys.stderr.write(tabulate(table_data))
         sys.stderr.write("\n\n")
 
-    table_data = [[actual, predicted, count]
-                  for (predicted, actual), count in stats['table'].items()]
-    table_data.sort()
 
-    sys.stderr.write(tabulate(table_data,
-                              headers=['actual', 'predicted', 'count']))
-    sys.stderr.write("\n")
+    table_data = []
+
+    for actual in possible:
+        table_data.append([actual] +
+                          [stats['table'].get((predicted, actual), 0)
+                           for predicted in possible])
+    sys.stderr.write(tabulate(table_data, headers=possible))
+    sys.stderr.write("\n\n")
 
     scorer_model.dump(model_file)


### PR DESCRIPTION
Tables now look like this:

```
$ cat ../ores-wikimedia-config/datasets/enwiki.features_wp10.30k.tsv | ./utility train_test revscoring.scorer_models.RF ores.feature_lists.enwiki.wp10 revscoring.languages.english > foo
Accuracy: 0.5436973401619032

ROC-AUC:
-----  --------
A      0.699985
B      0.750562
C      0.783328
FA     0.90796
GA     0.849178
Start  0.860285
Stub   0.96958
-----  --------

         A     B     C    FA    GA    Start    Stub
-----  ---  ----  ----  ----  ----  -------  ------
A       21    19     4    37    50        1       0
B       47  1204   893   233   357      342      19
C       35   757  1145    51   297      546      30
FA     231   276   112  1819   807       10       0
GA     151   383   312   495  1532       41       0
Start   11   330   422     2    22     1638     449
Stub     3    44    47     4     0      416    2514
```
