### PR TITLE
Rudimentary Vietnamese support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,11 +101,11 @@ system.  These are for ``scipy`` and ``numpy``.
 
 Linux Mint 17.1:
 
-1. ``sudo apt-get install g++ gfortran liblapack-dev python3-dev myspell-pt myspell-fa myspell-en-au myspell-en-gb myspell-en-us myspell-en-za  myspell-fr aspell-id myspell-es``
+1. ``sudo apt-get install g++ gfortran liblapack-dev python3-dev myspell-pt myspell-fa myspell-en-au myspell-en-gb myspell-en-us myspell-en-za  myspell-fr aspell-id myspell-es hunspell-vi``
 
 Ubuntu 14.04:
 
-1. ``sudo apt-get install g++ gfortran liblapack-dev libopenblas-dev python3-dev myspell-pt myspell-fa myspell-en-au  myspell-en-gb myspell-en-us myspell-en-za myspell-fr aspell-id myspell-es``
+1. ``sudo apt-get install g++ gfortran liblapack-dev libopenblas-dev python3-dev myspell-pt myspell-fa myspell-en-au  myspell-en-gb myspell-en-us myspell-en-za myspell-fr aspell-id myspell-es hunspell-vi``
 
 Authors
 =======

--- a/revscoring/languages/__init__.py
+++ b/revscoring/languages/__init__.py
@@ -46,6 +46,11 @@ turkish
 .. automodule:: revscoring.languages.turkish
     :members:
 
+vietnamese
++++++++
+.. automodule:: revscoring.languages.vietnamese
+    :members:
+
 language
 ++++++++
 .. automodule:: revscoring.languages.language

--- a/revscoring/languages/tests/test_vietnamese.py
+++ b/revscoring/languages/tests/test_vietnamese.py
@@ -1,0 +1,34 @@
+from nose.tools import eq_
+
+from .. import language
+from ..vietnamese import (is_badword, is_informal_word, is_misspelled,
+                          is_stopword)
+
+def test_language():
+
+    assert is_badword()("đít")
+    assert is_badword()("ỉa")
+    assert is_badword()("Ỉa")
+    assert not is_badword()("trứng")
+    eq_(hash(is_badword), hash(language.is_badword))
+
+    assert is_informal_word()("hehe")
+    assert is_informal_word()("hihihihihihihihihi")
+    assert is_informal_word()("Wá")
+    assert not is_informal_word()("he")
+    eq_(hash(is_informal_word), hash(language.is_informal_word))
+
+    assert is_misspelled()("wjwkjb")
+    assert is_misspelled()("đuờng")
+    assert is_misspelled()("cug")
+    assert not is_misspelled()("ấy")
+    assert not is_misspelled()("giặt")
+    assert not is_misspelled()("lũy")
+    assert not is_misspelled()("luỹ")
+    eq_(hash(is_misspelled), hash(language.is_misspelled))
+
+    assert is_stopword()("như")
+    assert is_stopword()("cái")
+    assert is_stopword()("mà")
+    assert not is_stopword()("chó")
+    eq_(hash(is_stopword), hash(language.is_stopword))

--- a/revscoring/languages/vietnamese.py
+++ b/revscoring/languages/vietnamese.py
@@ -1,0 +1,68 @@
+import re
+import warnings
+
+import enchant
+
+from .language import Language, LanguageUtility
+
+# https://vi.wiktionary.org/wiki/Th%C3%A0nh_vi%C3%AAn:Laurent_Bouvier/Free_Vietnamese_Dictionary_Project_Vietnamese-Vietnamese#Allwiki_.28closed.29
+STOPWORDS = set("ai", "bằng", "bị", "bộ", "cho", "chưa", "chỉ", "cuối", "cuộc",
+                "các", "cách", "cái", "có", "cùng", "cũng", "cạnh", "cả", "cục",
+                "của", "dùng", "dưới", "dừng", "giữa", "gì", "hay", "hoặc",
+                "khi", "khác", "không", "luôn", "là", "làm", "lại", "mà", "mọi",
+                "mỗi", "một", "nhiều", "như", "nhưng", "nào", "này", "nữa",
+                "phải", "qua", "quanh", "quá", "ra", "rất", "sau", "sẽ", "sự",
+                "theo", "thành", "thêm", "thì", "thứ", "trong", "trên", "trước",
+                "trừ", "tuy", "tìm", "từng", "và", "vài", "vào", "vì", "vẫn",
+                "về", "với", "xuống", "đang", "đã", "được", "đấy", "đầu", "đủ")
+BAD_REGEXES = [
+    "[ck]ặ[tc]", "[ck]u", "cứt", "(dz?|gi)âm", "đái", "đéo", "đ[ụù].", "đĩ",
+    "đ[íị]t", "ỉa", "l[ôồ]n",
+    "dick", "cunt", "fag", "bitch", "shit", "fuck.*", "ass", "gay", "ghey",
+    "slut",
+]
+INFORMAL_REGEXES = [
+    "bợn", "bro", "chẳng", "ch[ớứ]", "cú", "đừng", "fải", "(he){2,}", "(hi)+",
+    "khỉ", "mày", "nghịch", "ngu", "ngụy", "nguỵ", "ok", "ơi", "quái", "thằng",
+    "thôi", "tui", "ừ", "vời", "wái?", "zì",
+    "moron", "retard", "stupid",
+]
+BAD_REGEX = re.compile("|".join(BAD_REGEXES))
+INFORMAL_REGEX = re.compile("|".join(INFORMAL_REGEXES))
+DICTIONARY = enchant.Dict("vi")
+
+def stem_word_process():
+    def stem_word(word):
+        return word.lower()
+    return stem_word
+stem_word = LanguageUtility("stem_word", stem_word_process)
+
+def is_badword_process():
+    def is_badword(word):
+        return bool(BAD_REGEX.match(word.lower()))
+    return is_badword
+is_badword = LanguageUtility("is_badword", is_badword_process)
+
+def is_informal_word_process():
+    def is_informal_word(word):
+        return bool(INFORMAL_REGEX.match(word.lower()))
+    return is_informal_word
+is_informal_word = LanguageUtility("is_informal_word",
+    is_informal_word_process, depends_on=[])
+
+def is_misspelled_process():
+    def is_misspelled(word):
+        return not DICTIONARY.check(word)
+    return is_misspelled
+
+is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process)
+
+def is_stopword_process():
+    def is_stopword(word):
+        return word.lower() in STOPWORDS
+    return is_stopword
+is_stopword = LanguageUtility("is_stopword", is_stopword_process)
+
+vietnamese = Language("revscoring.languages.vietnamese",
+                      [stem_word, is_badword, is_informal_word, is_misspelled,
+                       is_stopword])


### PR DESCRIPTION
This PR adds rudimentary Vietnamese support, in every sense of the word rudimentary:

* It depends on the [hunspell-vi](https://packages.debian.org/stretch/hunspell-vi) package, which is hopefully based on [1ec5/hunspell-vi](https://github.com/1ec5/hunspell-vi).
* Hopefully the word list includes both the traditional and reformed diacritic placement. And hopefully we don’t have to worry about Unicode Normalization Form D (combining characters). An NFC canonicalization step could be added to vietnamese.py; MediaWiki already does this to all page content.
* This project only looks at individual words as separated by spaces, but Vietnamese abounds in compound words in which each syllable is separated by a space. So all three word lists are a small fraction of what they could be if bigram or trigram analysis were performed. Some examples:
 * “Cho nên” means “so” (definitely a stop word), but “cho” means “give” and “nên” can also appear in “trở nên” (become).
 * “Dương vật” is definitely a bad word, but “dương” also appears in “Thái Bình Dương” (Pacific Ocean) and “vật” appears in “vật học” (physics), among plenty of other acceptable words.
* Still, I feel pretty good about the informal list, which catches some very common indicators of talk page content and forum-speak.

My Mac isn’t set up yet to build and test this PR, but I appreciate any eyes that can be applied to it in the meantime, such as @halfak’s. This PR is also being [tracked in Phabricator](https://phabricator.wikimedia.org/T106094) as part of the Wikimanía 2015 Hackathon.