### PR TITLE
Selective language imports

### DIFF
--- a/revscoring/languages/__init__.py
+++ b/revscoring/languages/__init__.py
@@ -58,10 +58,3 @@ language
 
 from .language import Language, LanguageUtility
 from .language import stem_word, is_badword, is_misspelled, is_stopword, is_informal_word
-from .english import english
-from .french import french
-from .indonesian import indonesian
-from .persian import persian
-from .portuguese import portuguese
-from .spanish import spanish
-from .turkish import turkish

--- a/revscoring/languages/english.py
+++ b/revscoring/languages/english.py
@@ -1,5 +1,5 @@
 import re
-import warnings
+import sys
 
 import enchant
 from nltk.corpus import stopwords
@@ -90,8 +90,10 @@ def is_stopword_process():
     return is_stopword
 is_stopword = LanguageUtility("is_stopword", is_stopword_process)
 
-english = Language("revscoring.languages.english",
-                   [stem_word, is_badword, is_misspelled, is_stopword, is_informal_word])
+sys.modules[__name__] = Language(
+    __name__,
+    [stem_word, is_badword, is_misspelled, is_stopword, is_informal_word]
+)
 """
 Implements :class:`~revscoring.languages.language.Language` for all variants of
 English (e.g. US & British).  Comes complete with all language utilities.

--- a/revscoring/languages/english.py
+++ b/revscoring/languages/english.py
@@ -37,23 +37,28 @@ BAD_REGEXES = [
     "zipperhead"
 ]
 INFORMAL_REGEXES = [
-    'awesome', 'awesomest', 'awsome',
+    "ain'?t", 'awe?some(r|st)?',
     'bla', 'blah', 'boner', 'boobs', 'bullshit',
-    'cant', 'coolest', 'crap',
+    "can'?t", "[ck](oo|ew)l(er|est)?", 'crap',
     "don'?t", "dumb", "dumbass",
+    "goodbye",
     "haha", "hello", "hey",
-    "kool",
-    "lol", "luv",
+    "i"
+    "lol", "l(oo+|u)ve",
     "meow",
-    'shove', 'smelly', 'sooo', 'stinky', 'sucking', 'sux', "shouldn\'t"
+    'shove', 'smelly', 'soo+', 'stinky', 'suck(ing|er)?', 'sux', "shouldn\'t"
     "tits",
-    "wasn'?t", "wuz", "won'?t",
-    'yall', 'yay', 'yea', 'yolo'
+    "wasn'?t", "wuz", "won'?t", "woof",
+    "ya'?ll", 'yay', 'yea', 'yolo'
 ]
 BAD_REGEX = re.compile("|".join(BAD_REGEXES))
 INFORMAL_REGEX = re.compile("|".join(INFORMAL_REGEXES))
-DICTIONARY = enchant.Dict("en")
-
+try:
+    DICTIONARY = enchant.Dict("en")
+except enchant.errors.DictNotFoundError:
+    raise ImportError("No enchant-compatible dictionary found for 'en'.  " +
+                      "Consider installing 'myspell-en-au', 'myspell-en-gb', " +
+                      "'myspell-en-us' and/or 'myspell-en-za'.")
 
 def stem_word_process():
     def stem_word(word):

--- a/revscoring/languages/french.py
+++ b/revscoring/languages/french.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 
 import enchant
@@ -51,9 +52,11 @@ def is_stopword_process():
     return is_stopword
 is_stopword = LanguageUtility("is_stopword", is_stopword_process, depends_on=[])
 
-french = Language("revscoring.languages.french",
-                      [stem_word, is_badword, is_misspelled, is_stopword])
+sys.modules[__name__] = Language(
+    __name__,
+    [stem_word, is_badword, is_misspelled, is_stopword]
+)
 """
 Implements :class:`~revscoring.languages.language.Language` for French.  Comes
-complete with all language utilities. 
+complete with all language utilities.
 """

--- a/revscoring/languages/french.py
+++ b/revscoring/languages/french.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 
 import enchant
 from nltk.corpus import stopwords
@@ -23,7 +22,11 @@ BADWORDS = set([
 ])
 
 STEMMED_BADWORDS = set(STEMMER.stem(w) for w in BADWORDS)
-DICTIONARY = enchant.Dict("fr")
+try:
+    DICTIONARY = enchant.Dict("fr")
+except enchant.errors.DictNotFoundError:
+    raise ImportError("No enchant-compatible dictionary found for 'fr'.  " +
+                      "Consider installing 'myspell-fr'.")
 
 def stem_word_process():
     def stem_word(word):

--- a/revscoring/languages/indonesian.py
+++ b/revscoring/languages/indonesian.py
@@ -1,5 +1,5 @@
 import re
-import warnings
+import sys
 
 import enchant
 
@@ -108,8 +108,10 @@ is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
                                 depends_on=[])
 
 
-indonesian = Language("revscoring.languages.indonesian",
-                   [is_badword, is_misspelled, is_stopword])
+sys.modules[__name__] = Language(
+    __name__,
+    [is_badword, is_misspelled, is_stopword]
+)
 """
 Implements :class:`~revscoring.languages.language.Language` for Indonesian.
 :data:`~revscoring.languages.language.is_badword`,

--- a/revscoring/languages/indonesian.py
+++ b/revscoring/languages/indonesian.py
@@ -86,7 +86,11 @@ BAD_REGEXES = [
         "toket", "tzcesar", "thailaland", "thaicia"
 ]
 BAD_REGEX = re.compile("|".join(BAD_REGEXES))
-DICTIONARY = enchant.Dict("id")
+try:
+    DICTIONARY = enchant.Dict("id")
+except enchant.errors.DictNotFoundError:
+    raise ImportError("No enchant-compatible dictionary found for 'id'.  " +
+                      "Consider installing 'aspell-id'.")
 
 def is_badword_process():
     def is_badword(word):

--- a/revscoring/languages/language.py
+++ b/revscoring/languages/language.py
@@ -69,7 +69,9 @@ class LanguageUtility(dependencies.Dependent):
     """
     Implements a dependency wrapper for a utility functions.
     """
-    pass
+
+    def __hash__(self):
+        return hash(('language_utility', self.name))
 
 # Define placeholder utilities.  These will need to be replaced inside of a
 # language, but they will provide names to match against within the cache.

--- a/revscoring/languages/persian.py
+++ b/revscoring/languages/persian.py
@@ -1,16 +1,20 @@
-import warnings
+import sys
 
 import enchant
 
 from .language import Language, LanguageUtility
 
-DICTIONARY = enchant.Dict("fa")
+try:
+    DICTIONARY = enchant.Dict("fa")
+except enchant.errors.DictNotFoundError:
+    raise ImportError("No enchant-compatible dictionary found for 'fa'.  " +
+                      "Consider installing 'myspell-fa'.")
+
 BADWORDS = set([
     "کیرم", "ایتالیک", "کونی", "کیر", "فرمود", "آله", "فرموده", "فرمودند",
     "جنده", "برووتو", "لعنت", "کون", "السلام", "جمهورمحترم", "کونی",
     "کاکاسیاه", "آشغال", "گائیدم", "گوزیده", "مشنگ", "ننتو", "بخواب"
 ])
-
 
 def is_misspelled_process():
     def is_misspelled(word):

--- a/revscoring/languages/persian.py
+++ b/revscoring/languages/persian.py
@@ -28,7 +28,7 @@ is_badword = LanguageUtility("is_badword", is_badword_process, depends_on=[])
 is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
                                 depends_on=[])
 
-persian = Language("revscoring.languages.persian", [is_badword, is_misspelled])
+sys.modules[__name__] = Language(__name__, [is_badword, is_misspelled])
 """
 Implements :class:`~revscoring.languages.language.Language` for Persian/Farsi.
 :data:`~revscoring.languages.language.is_badword` and

--- a/revscoring/languages/portuguese.py
+++ b/revscoring/languages/portuguese.py
@@ -213,8 +213,10 @@ def is_stopword_process():
     return is_stopword
 is_stopword = LanguageUtility("is_stopword", is_stopword_process, depends_on=[])
 
-portuguese = Language("revscoring.languages.portuguese",
-                      [stem_word, is_badword, is_misspelled, is_stopword])
+sys.modules[__name__] = Language(
+    __name__,
+    [stem_word, is_badword, is_misspelled, is_stopword]
+)
 """
 Implements :class:`~revscoring.languages.language.Language` for Portuguese.
 Comes complete with all language utilities.

--- a/revscoring/languages/portuguese.py
+++ b/revscoring/languages/portuguese.py
@@ -1,4 +1,4 @@
-import warnings
+import sys
 
 import enchant
 from nltk.corpus import stopwords
@@ -184,7 +184,11 @@ BADWORDS = set([
     "zipi", "zizi", "zoando", "zoar", "zoeira", "zuando", "zuar", "zueira"
 ])
 STEMMED_BADWORDS = set(STEMMER.stem(w) for w in BADWORDS)
-DICTIONARY = enchant.Dict("pt")
+try:
+    DICTIONARY = enchant.Dict("pt")
+except enchant.errors.DictNotFoundError:
+    raise ImportError("No enchant-compatible dictionary found for 'pt'.  " +
+                      "Consider installing 'myspell-pt'.")
 
 def stem_word_process():
     def stem_word(word):

--- a/revscoring/languages/spanish.py
+++ b/revscoring/languages/spanish.py
@@ -116,6 +116,7 @@ def is_stopword_process():
     return is_stopword
 is_stopword = LanguageUtility("is_stopword", is_stopword_process)
 
-spanish = Language("revscoring.languages.spanish",
-                   [stem_word, is_badword, is_informal_word, is_misspelled,
-                    is_stopword])
+sys.modules[__name__] = Language(
+    __name__,
+    [stem_word, is_badword, is_informal_word, is_misspelled, is_stopword]
+)

--- a/revscoring/languages/spanish.py
+++ b/revscoring/languages/spanish.py
@@ -1,5 +1,5 @@
 import re
-import warnings
+import sys
 
 import enchant
 from nltk.corpus import stopwords
@@ -82,7 +82,11 @@ INFORMAL_REGEXES = [
 ]
 BAD_REGEX = re.compile("|".join(BAD_REGEXES))
 INFORMAL_REGEX = re.compile("|".join(INFORMAL_REGEXES))
-DICTIONARY = enchant.Dict("es")
+try:
+    DICTIONARY = enchant.Dict("es")
+except enchant.errors.DictNotFoundError:
+    raise ImportError("No enchant-compatible dictionary found for 'es'.  " +
+                      "Consider installing 'myspell-es'.")
 
 def stem_word_process():
     def stem_word(word):

--- a/revscoring/languages/tests/test_english.py
+++ b/revscoring/languages/tests/test_english.py
@@ -1,28 +1,38 @@
 from nose.tools import eq_
 
-from .. import language
-from ..english import is_badword, is_misspelled, is_stopword, stem_word
+from .. import english, language
 
 
 def test_language():
 
-    eq_(stem_word()("shitting"), "shit")
-    eq_(stem_word()("Shitting"), "shit")
-    eq_(hash(stem_word), hash(language.stem_word))
+    stem_word = english.solve(language.stem_word)
 
-    assert is_badword()("shit")
-    assert is_badword()("shitty")
-    assert is_badword()("Shitty")
-    assert not is_badword()("hat")
-    eq_(hash(is_badword), hash(language.is_badword))
+    eq_(stem_word("shitting"), "shit")
+    eq_(stem_word("Shitting"), "shit")
 
-    assert is_misspelled()("wjwkjb")
-    assert not is_misspelled()("waffles")
-    assert not is_misspelled()("Waffles")
-    eq_(hash(is_misspelled), hash(language.is_misspelled))
+    is_badword = english.solve(language.is_badword)
 
-    assert is_stopword()("A")
-    assert is_stopword()("in")
-    assert is_stopword()("about")
-    assert not is_stopword()("waffles")
-    eq_(hash(is_stopword), hash(language.is_stopword))
+    assert is_badword("shit")
+    assert is_badword("shitty")
+    assert is_badword("Shitty")
+    assert not is_badword("hat")
+
+    is_informal_word = english.solve(language.is_informal_word)
+
+    assert is_informal_word("kewlest")
+    assert is_informal_word("won't")
+    assert is_informal_word("cant")
+    assert not is_informal_word("hat")
+
+    is_misspelled = english.solve(language.is_misspelled)
+
+    assert is_misspelled("wjwkjb")
+    assert not is_misspelled("waffles")
+    assert not is_misspelled("Waffles")
+
+    is_stopword = english.solve(language.is_stopword)
+
+    assert is_stopword("A")
+    assert is_stopword("in")
+    assert is_stopword("about")
+    assert not is_stopword("waffles")

--- a/revscoring/languages/tests/test_french.py
+++ b/revscoring/languages/tests/test_french.py
@@ -1,28 +1,31 @@
 from nose.tools import eq_
 
-from .. import language
-from ..french import is_badword, is_misspelled, is_stopword, stem_word
+from .. import french, language
 
 
 def test_language():
 
-    eq_(stem_word()("merdique"), "merdiqu")
-    eq_(stem_word()("Merdique"), "merdiqu")
-    eq_(hash(stem_word), hash(language.stem_word))
+    stem_word = french.solve(language.stem_word)
 
-    assert is_badword(stem_word())("merde")
-    assert is_badword(stem_word())("merdique")
-    assert is_badword(stem_word())("Merdique")
-    assert not is_badword(stem_word())("Chapeau")
-    eq_(hash(is_badword), hash(language.is_badword))
+    eq_(stem_word("merdique"), "merdiqu")
+    eq_(stem_word("Merdique"), "merdiqu")
 
-    assert is_misspelled()("wjwkjb")
-    assert not is_misspelled()("gaufres")
-    assert not is_misspelled()("Gaufres")
-    eq_(hash(is_misspelled), hash(language.is_misspelled))
+    is_badword = french.solve(language.is_badword)
 
-    assert is_stopword()("A")
-    assert is_stopword()("dans")
-    assert is_stopword()("notre")
-    assert not is_stopword()("gaufres")
-    eq_(hash(is_stopword), hash(language.is_stopword))
+    assert is_badword("merde")
+    assert is_badword("merdique")
+    assert is_badword("Merdique")
+    assert not is_badword("Chapeau")
+
+    is_misspelled = french.solve(language.is_misspelled)
+
+    assert is_misspelled("wjwkjb")
+    assert not is_misspelled("gaufres")
+    assert not is_misspelled("Gaufres")
+
+    is_stopword = french.solve(language.is_stopword)
+
+    assert is_stopword("A")
+    assert is_stopword("dans")
+    assert is_stopword("notre")
+    assert not is_stopword("gaufres")

--- a/revscoring/languages/tests/test_indonesian.py
+++ b/revscoring/languages/tests/test_indonesian.py
@@ -1,23 +1,25 @@
 from nose.tools import eq_
 
-from .. import language
-from ..indonesian import is_badword, is_misspelled, is_stopword
+from .. import indonesian, language
 
 
 def test_language():
 
-    assert is_badword()("gestapo")
-    assert is_badword()("geftapo")
-    assert is_badword()("Gestapo")
-    assert not is_badword()("hat")
-    eq_(hash(is_badword), hash(language.is_badword))
+    is_badword = indonesian.solve(language.is_badword)
 
-    assert is_misspelled()("mungkinkahSAKJDHAKS")
-    assert not is_misspelled()("mungkinkah")
-    assert not is_misspelled()("Mungkinkah")
-    eq_(hash(is_misspelled), hash(language.is_misspelled))
+    assert is_badword("gestapo")
+    assert is_badword("geftapo")
+    assert is_badword("Gestapo")
+    assert not is_badword("hat")
 
-    assert is_stopword()("mungkinkah")
-    assert is_stopword()("siapa")
-    assert not is_stopword()("belajar")
-    eq_(hash(is_stopword), hash(language.is_stopword))
+    is_misspelled = indonesian.solve(language.is_misspelled)
+
+    assert is_misspelled("mungkinkahSAKJDHAKS")
+    assert not is_misspelled("mungkinkah")
+    assert not is_misspelled("Mungkinkah")
+
+    is_stopword = indonesian.solve(language.is_stopword)
+
+    assert is_stopword("mungkinkah")
+    assert is_stopword("siapa")
+    assert not is_stopword("belajar")

--- a/revscoring/languages/tests/test_persian.py
+++ b/revscoring/languages/tests/test_persian.py
@@ -1,8 +1,16 @@
 from nose.tools import eq_
 
-from ..persian import is_misspelled
+from .. import language, persian
 
 
 def test_language():
-    assert is_misspelled()("Notafarsiword")
-    assert not is_misspelled()("مهم")
+
+    is_misspelled = persian.solve(language.is_misspelled)
+
+    assert is_misspelled("Notafarsiword")
+    assert not is_misspelled("مهم")
+
+    is_badword = persian.solve(language.is_badword)
+
+    assert is_badword("کیرم")
+    assert not is_badword("hat")

--- a/revscoring/languages/tests/test_portuguese.py
+++ b/revscoring/languages/tests/test_portuguese.py
@@ -1,21 +1,29 @@
 from nose.tools import eq_
 
-from ..portuguese import is_badword, is_misspelled, is_stopword, stem_word
+from .. import language, portuguese
 
 
 def test_language():
-    
-    eq_(stem_word()("merda"), "merd")
-    eq_(stem_word()("Merda"), "merd")
-    
-    assert is_badword(stem_word())("merda")
-    assert is_badword(stem_word())("merdar")
-    assert is_badword(stem_word())("Merdar")
-    assert not is_badword(stem_word())("arvere")
-    
-    assert is_misspelled()("wjwkjb")
-    assert not is_misspelled()("Esta")
-    
-    assert is_stopword()("A")
-    assert is_stopword()("o")
-    assert not is_stopword()("arvere")
+
+    stem_word = portuguese.solve(language.stem_word)
+
+    eq_(stem_word("merda"), "merd")
+    eq_(stem_word("Merda"), "merd")
+
+    is_badword = portuguese.solve(language.is_badword)
+
+    assert is_badword("merda")
+    assert is_badword("merdar")
+    assert is_badword("Merdar")
+    assert not is_badword("arvere")
+
+    is_misspelled = portuguese.solve(language.is_misspelled)
+
+    assert is_misspelled("wjwkjb")
+    assert not is_misspelled("Esta")
+
+    is_stopword = portuguese.solve(language.is_stopword)
+
+    assert is_stopword("A")
+    assert is_stopword("o")
+    assert not is_stopword("arvere")

--- a/revscoring/languages/tests/test_spanish.py
+++ b/revscoring/languages/tests/test_spanish.py
@@ -1,35 +1,38 @@
 from nose.tools import eq_
 
-from .. import language
-from ..spanish import (is_badword, is_informal_word, is_misspelled,
-                       is_stopword, stem_word)
+from .. import language, spanish
 
 
 def test_language():
 
-    eq_(stem_word()("Huevos"), "huev")
-    eq_(stem_word()("Vamar"), "vam")
-    eq_(hash(stem_word), hash(language.stem_word))
+    stem_word = spanish.solve(language.stem_word)
 
-    assert is_badword()("huevos")
-    assert is_badword()("mamon")
-    assert is_badword()("Mamón")
-    assert not is_badword()("hat")
-    eq_(hash(is_badword), hash(language.is_badword))
+    eq_(stem_word("Huevos"), "huev")
+    eq_(stem_word("Vamar"), "vam")
 
-    assert is_informal_word()("jaja")
-    assert is_informal_word()("jejejejeje")
-    assert is_informal_word()("Chido")
-    assert not is_informal_word()("Mamón")
-    eq_(hash(is_informal_word), hash(language.is_informal_word))
+    is_badword = spanish.solve(language.is_badword)
 
-    assert is_misspelled()("wjwkjb")
-    assert not is_misspelled()("que")
-    assert not is_misspelled()("Que")
-    eq_(hash(is_misspelled), hash(language.is_misspelled))
+    assert is_badword("huevos")
+    assert is_badword("mamon")
+    assert is_badword("Mamón")
+    assert not is_badword("hat")
 
-    assert is_stopword()("que")
-    assert is_stopword()("el")
-    assert is_stopword()("por")
-    assert not is_stopword()("waffles")
-    eq_(hash(is_stopword), hash(language.is_stopword))
+    is_informal_word = spanish.solve(language.is_informal_word)
+
+    assert is_informal_word("jaja")
+    assert is_informal_word("jejejejeje")
+    assert is_informal_word("Chido")
+    assert not is_informal_word("Mamón")
+
+    is_misspelled = spanish.solve(language.is_misspelled)
+
+    assert is_misspelled("wjwkjb")
+    assert not is_misspelled("que")
+    assert not is_misspelled("Que")
+
+    is_stopword = spanish.solve(language.is_stopword)
+
+    assert is_stopword("que")
+    assert is_stopword("el")
+    assert is_stopword("por")
+    assert not is_stopword("waffles")

--- a/revscoring/languages/tests/test_turkish.py
+++ b/revscoring/languages/tests/test_turkish.py
@@ -1,13 +1,18 @@
 from nose.tools import eq_
 
-from ..turkish import is_badword, is_stopword
+from .. import language, turkish
 
 
 def test_language():
-    assert is_badword()("Mal")
-    assert is_badword()("orospu çocuğu")
-    assert not is_badword()("Resim")
-    
-    assert is_stopword()("bazı")
-    assert is_stopword()("O")
-    assert not is_stopword()("Güzergah")
+
+    is_badword = turkish.solve(language.is_badword)
+
+    assert is_badword("Mal")
+    assert is_badword("orospu çocuğu")
+    assert not is_badword("Resim")
+
+    is_stopword = turkish.solve(language.is_stopword)
+
+    assert is_stopword("bazı")
+    assert is_stopword("O")
+    assert not is_stopword("Güzergah")

--- a/revscoring/languages/tests/test_vietnamese.py
+++ b/revscoring/languages/tests/test_vietnamese.py
@@ -1,40 +1,42 @@
 from nose.tools import eq_
 
-from .. import language
-from ..vietnamese import (is_badword, is_informal_word, is_misspelled,
-                          is_stopword)
+from .. import language, vietnamese
 
 
 def test_language():
 
-    assert is_badword()("đít")
-    assert is_badword()("ỉa")
-    assert is_badword()("Ỉa")
-    assert is_badword()("assface")
-    assert not is_badword()("trứng")
-    assert not is_badword()("bass")
-    eq_(hash(is_badword), hash(language.is_badword))
+    is_badword = vietnamese.solve(language.is_badword)
 
-    assert is_informal_word()("hehe")
-    assert is_informal_word()("hihihihihihihihihi")
-    assert is_informal_word()("Wá")
-    assert not is_informal_word()("he")
-    eq_(hash(is_informal_word), hash(language.is_informal_word))
+    assert is_badword("đít")
+    assert is_badword("ỉa")
+    assert is_badword("Ỉa")
+    assert is_badword("assface")
+    assert not is_badword("trứng")
+    assert not is_badword("bass")
 
-    assert is_misspelled()("wjwkjb")
-    assert is_misspelled()("đuờng")
-    assert is_misspelled()("cug")
-    assert not is_misspelled()("ấy")
-    assert not is_misspelled()("giặt")
+    is_informal_word = vietnamese.solve(language.is_informal_word)
+
+    assert is_informal_word("hehe")
+    assert is_informal_word("hihihihihihihihihi")
+    assert is_informal_word("Wá")
+    assert not is_informal_word("he")
+
+    is_misspelled = vietnamese.solve(language.is_misspelled)
+
+    assert is_misspelled("wjwkjb")
+    assert is_misspelled("đuờng")
+    assert is_misspelled("cug")
+    assert not is_misspelled("ấy")
+    assert not is_misspelled("giặt")
 
     # TODO: this fails with the most recent hunspell-vi package
-    #assert not is_misspelled()("lũy")
+    #assert not is_misspelled("lũy")
 
-    assert not is_misspelled()("luỹ")
-    eq_(hash(is_misspelled), hash(language.is_misspelled))
+    assert not is_misspelled("luỹ")
 
-    assert is_stopword()("như")
-    assert is_stopword()("cái")
-    assert is_stopword()("mà")
-    assert not is_stopword()("chó")
-    eq_(hash(is_stopword), hash(language.is_stopword))
+    is_stopword = vietnamese.solve(language.is_stopword)
+
+    assert is_stopword("như")
+    assert is_stopword("cái")
+    assert is_stopword("mà")
+    assert not is_stopword("chó")

--- a/revscoring/languages/turkish.py
+++ b/revscoring/languages/turkish.py
@@ -41,8 +41,10 @@ def is_stopword_process():
 is_stopword = LanguageUtility("is_stopword", is_stopword_process, depends_on=[])
 
 
-turkish = Language("revscoring.languages.turkish",
-                   [is_badword, is_stopword])
+sys.modules[__name__] = Language(
+    __name__,
+    [is_badword, is_stopword]
+)
 """
 Implements :class:`~revscoring.languages.language.Language` for Turkish.
 :data:`~revscoring.languages.language.is_badword` and

--- a/revscoring/languages/turkish.py
+++ b/revscoring/languages/turkish.py
@@ -1,3 +1,5 @@
+import sys
+
 from nltk.corpus import stopwords
 
 from .language import Language, LanguageUtility

--- a/revscoring/languages/vietnamese.py
+++ b/revscoring/languages/vietnamese.py
@@ -1,5 +1,5 @@
 import re
-import warnings
+import sys
 
 import enchant
 
@@ -31,7 +31,11 @@ INFORMAL_REGEXES = [
 ]
 BAD_REGEX = re.compile("|".join(BAD_REGEXES))
 INFORMAL_REGEX = re.compile("|".join(INFORMAL_REGEXES))
-DICTIONARY = enchant.Dict("vi")
+try:
+    DICTIONARY = enchant.Dict("vi")
+except enchant.errors.DictNotFoundError:
+    raise ImportError("No enchant-compatible dictionary found for 'vi'.  " +
+                      "Consider installing 'hunspell-vi'.")
 
 def stem_word_process():
     def stem_word(word):

--- a/revscoring/languages/vietnamese.py
+++ b/revscoring/languages/vietnamese.py
@@ -65,6 +65,7 @@ def is_stopword_process():
     return is_stopword
 is_stopword = LanguageUtility("is_stopword", is_stopword_process)
 
-vietnamese = Language("revscoring.languages.vietnamese",
-                      [stem_word, is_badword, is_informal_word, is_misspelled,
-                       is_stopword])
+sys.modules[__name__] = Language(
+    __name__,
+    [stem_word, is_badword, is_informal_word, is_misspelled, is_stopword]
+)


### PR DESCRIPTION
Language imports now only execute when explicitly imported.  This allows a developer to only install the enchant dictionaries that are to be used.  

