### PR TITLE
Removes reference to language in APIExtractor.from_config

### DIFF
--- a/revscoring/extractors/api.py
+++ b/revscoring/extractors/api.py
@@ -1,9 +1,8 @@
 import logging
 from collections import defaultdict
 
-from mw import Namespace, Timestamp, api
-
 import yamlconf
+from mw import Namespace, Timestamp, api
 
 from .. import dependencies
 from ..datasources import (Datasource, RevisionMetadata, UserInfo,
@@ -375,6 +374,4 @@ class APIExtractor(Extractor):
         session = api.Session(section['url'],
                               user_agent=section['user_agent'])
 
-        language = Language.from_config(config, section['language'])
-
-        return cls(session, language)
+        return cls(session)

--- a/revscoring/extractors/tests/test_api.py
+++ b/revscoring/extractors/tests/test_api.py
@@ -132,3 +132,17 @@ def test_namespace_map_from_doc():
 
     eq_(len(namespace_map), 3)
     eq_(sum(ns.content for ns in namespace_map.values()), 1)
+
+
+def test_from_config():
+    config = {
+        'extractors': {
+            'enwiki': {
+                'url': 'https://en.wikipedia.org/w/api.php',
+                'user_agent': 'revscoring tests'
+            }
+        }
+    }
+
+    extractor = api.APIExtractor.from_config(config, 'enwiki')
+    # Doesn't error


### PR DESCRIPTION
Also, adds a test for from_config so mistakes like this won't happen in the future. 