### PR TITLE
Silences a utf16 encoding warning in enchant.

### DIFF
--- a/revscoring/languages/space_delimited/revision.py
+++ b/revscoring/languages/space_delimited/revision.py
@@ -4,7 +4,7 @@ from ...features import Feature
 from ..meta.infonoise import Infonoise
 from ..meta.regex_extractors import TextRegexExtractor
 from ..meta.token_filter import TokenFilter
-from .util import token_is_word
+from .util import token_is_word, utf16_cleanup
 
 
 def raise_rnf():
@@ -137,7 +137,7 @@ class Revision:
             """
 
     def in_dictionary(self, word):
-        return self.language.resources.dictionary.check(str(word))
+        return self.language.resources.dictionary.check(utf16_cleanup(word))
 
     def not_in_dictionary(self, word):
-        return not self.language.resources.dictionary.check(str(word))
+        return not self.in_dictionary(word)

--- a/revscoring/languages/space_delimited/tests/test_space_delimited.py
+++ b/revscoring/languages/space_delimited/tests/test_space_delimited.py
@@ -1,6 +1,7 @@
 import pickle
 from collections import namedtuple
 
+import enchant
 from nose.tools import eq_
 
 from ....datasources import parent_revision, revision
@@ -76,7 +77,7 @@ def test_infonoise():
 
 def test_misspellings():
     Dictionary = namedtuple("Dictionary", ["check"])
-    dictionary = Dictionary(lambda w: w != "misspelled")  # First char
+    dictionary = Dictionary(lambda w: w != "misspelled")
 
     sd = SpaceDelimited("fake", dictionary=dictionary)
 
@@ -90,6 +91,17 @@ def test_misspellings():
 
     cache = {parent_revision.text: None}
     eq_(solve(sd.parent_revision.misspellings_list, cache=cache), [])
+
+
+def test_utf16_issue():
+    dictionary = enchant.Dict('en')
+
+    sd = SpaceDelimited("fake", dictionary=dictionary)
+
+    cache = {revision.text: "𐎤𐎢𐎽𐎢𐏁"}
+    eq_(solve(sd.revision.misspellings_list, cache=cache), ["𐎤𐎢𐎽𐎢𐏁"])
+
+
 
 BADWORDS = [r"bad(words)?"]
 Dictionary = namedtuple("Dictionary", ["check"])

--- a/revscoring/languages/space_delimited/util.py
+++ b/revscoring/languages/space_delimited/util.py
@@ -1,2 +1,17 @@
+REPLACEMENT_CHAR = "\uFFFD"
+
+
 def token_is_word(t):
     return t.type == "word"
+
+
+def utf16_cleanup(token):
+    """
+    Removes chars that can't be represented in two bytes.  This is important
+    since `enchant` will expect that all strings passed to it are two-byte
+    chars and print "This UTF-8 encoding can't convert to UTF-16:" if it can't
+    decode.  This prevents that problem.
+    See https://github.com/rfk/pyenchant/issues/58
+    """
+    return "".join(c if ord(c) < 2**16 else REPLACEMENT_CHAR
+                   for c in token)


### PR DESCRIPTION
Also fixes a couple of related tests that shouldn't have been failing.  

This PR is a stopgap until a fix is deployed in pyenchant.  See https://github.com/rfk/pyenchant/pull/59