### PR TITLE
Adds model_info storage & utility

### DIFF
--- a/revscoring/scorer_models/tests/test_nb.py
+++ b/revscoring/scorer_models/tests/test_nb.py
@@ -1,15 +1,19 @@
 from ..nb import BernoulliNBModel, GaussianNBModel, MultinomialNBModel
-from .util import FEATURES, pickle_and_unpickle, train_score
+from .util import (FEATURES, get_and_format_info, pickle_and_unpickle,
+                   train_score)
 
 
 def test_gaussian_nb():
     model = GaussianNBModel(FEATURES)
+    get_and_format_info(model)
     train_score(model)
     pickle_and_unpickle(model)
+    get_and_format_info(model)
 
 
 def test_multinomial_nb():
-    MultinomialNBModel(FEATURES)
+    model = MultinomialNBModel(FEATURES)
+    get_and_format_info(model)
 
     # Fails due to negative feature values.
     # train_score(model)
@@ -18,5 +22,7 @@ def test_multinomial_nb():
 
 def test_bernoulli_nb():
     model = BernoulliNBModel(FEATURES)
+    get_and_format_info(model)
     train_score(model)
     pickle_and_unpickle(model)
+    get_and_format_info(model)

--- a/revscoring/scorer_models/tests/test_rf.py
+++ b/revscoring/scorer_models/tests/test_rf.py
@@ -1,8 +1,11 @@
 from ..rf import RFModel
-from .util import FEATURES, pickle_and_unpickle, train_score
+from .util import (FEATURES, get_and_format_info, pickle_and_unpickle,
+                   train_score)
 
 
 def test_rf():
     model = RFModel(FEATURES)
+    get_and_format_info(model)
     train_score(model)
     pickle_and_unpickle(model)
+    get_and_format_info(model)

--- a/revscoring/scorer_models/tests/test_svc.py
+++ b/revscoring/scorer_models/tests/test_svc.py
@@ -1,20 +1,27 @@
 from ..svc import LinearSVCModel, RBFSVCModel, SVCModel
-from .util import FEATURES, pickle_and_unpickle, train_score
+from .util import (FEATURES, get_and_format_info, pickle_and_unpickle,
+                   train_score)
 
 
 def test_svc():
     model = SVCModel(FEATURES)
+    get_and_format_info(model)
     train_score(model)
     pickle_and_unpickle(model)
+    get_and_format_info(model)
 
 
 def test_linear_svc():
     model = LinearSVCModel(FEATURES)
+    get_and_format_info(model)
     train_score(model)
     pickle_and_unpickle(model)
+    get_and_format_info(model)
 
 
 def test_rbf_svc():
     model = RBFSVCModel(FEATURES)
+    get_and_format_info(model)
     train_score(model)
     pickle_and_unpickle(model)
+    get_and_format_info(model)

--- a/revscoring/scorer_models/tests/util.py
+++ b/revscoring/scorer_models/tests/util.py
@@ -63,3 +63,9 @@ def pickle_and_unpickle(model):
         [feature.name for feature in model.features])
     eq_(type(reconstructed_model), type(model))
     train_score(reconstructed_model)
+
+
+def get_and_format_info(model):
+
+    assert model.info() is not None
+    print(model.format_info())

--- a/revscoring/scorer_models/util.py
+++ b/revscoring/scorer_models/util.py
@@ -1,9 +1,16 @@
 import numpy
 
 
-def normalize(v):
+def normalize(v, key=False):
     if isinstance(v, numpy.bool_):
         return bool(v)
+    elif isinstance(v, numpy.float):
+        return float(v)
+    elif isinstance(v, tuple):
+        if key:
+            return str(v)
+        else:
+            return list(v)
     else:
         return v
 
@@ -11,7 +18,8 @@ def normalize(v):
 def normalize_json(doc):
 
     if isinstance(doc, dict):
-        return {normalize_json(k): normalize_json(v) for k, v in doc.items()}
+        return {normalize(k, key=True): normalize_json(v)
+                for k, v in doc.items()}
     elif isinstance(doc, list):
         return [normalize_json(v) for v in doc]
     else:

--- a/revscoring/utilities/model_info.py
+++ b/revscoring/utilities/model_info.py
@@ -1,0 +1,36 @@
+"""
+``revscoring score -h``
+::
+
+    Prints formatted information about a model file.
+
+
+    Usage:
+        module_info -h | --help
+        module_info <model-file> [--as-json]
+
+    Options:
+        -h --help     Prints this documentation
+        <model-file>  Path to a model file
+        --as-json     Output model info as a JSON blob
+"""
+import json
+
+import docopt
+
+from ..scorer_models import ScorerModel
+
+
+def main(argv=None):
+    args = docopt.docopt(__doc__, argv=argv)
+    scorer_model = ScorerModel.load(open(args['<model-file>'], 'rb'))
+    as_json = args['--as-json']
+
+    run(scorer_model, as_json)
+
+
+def run(scorer_model, as_json):
+    if not as_json:
+        print(scorer_model.format_info())
+    else:
+        print(json.dumps(scorer_model.info()))

--- a/revscoring/utilities/train_test.py
+++ b/revscoring/utilities/train_test.py
@@ -110,29 +110,10 @@ def run(feature_labels, model_file, scorer_model):
 
     scorer_model.train(train_set)
 
-    stats = scorer_model.test(test_set)
+    scorer_model.test(test_set)
 
-    possible = list(set(actual for _, actual in stats['table'].keys()))
-    possible.sort()
+    sys.stderr.write(scorer_model.format_info())
 
-    sys.stderr.write("Accuracy: {0}\n\n".format(stats['accuracy']))
-    if 'auc' in stats['roc']:
-        sys.stderr.write("ROC-AUC: {0}\n\n".format(stats['roc']['auc']))
-    else:
-        sys.stderr.write("ROC-AUC:\n")
-
-        table_data = [[comparison_label, stats['roc'][comparison_label]['auc']]
-                      for comparison_label in possible]
-        sys.stderr.write(tabulate(table_data))
-        sys.stderr.write("\n\n")
-
-    table_data = []
-
-    for actual in possible:
-        table_data.append([actual] +
-                          [stats['table'].get((predicted, actual), 0)
-                           for predicted in possible])
-    sys.stderr.write(tabulate(table_data, headers=possible))
     sys.stderr.write("\n\n")
 
     scorer_model.dump(model_file)


### PR DESCRIPTION
```
$ ./utility model_info models/enwiki.reverted.linear_svc.model
ScikitLearnClassifier
 - type: LinearSVC
 - version: 0.3.2
 - trained: 2015-10-02T16:22:43.574856

Accuracy: 0.7793696275071633

ROC-AUC: 0.8124735433078716

      False    True
--  -------  ------
 0     8850     274
 1     2119     623
```

Also is able to output raw JSON:
```
$ ./utility model_info models/enwiki.reverted.linear_svc.model --as-json
{"type": "LinearSVC", "version": "0.3.2", "stats": {"accuracy": 0.7793696275071633, "table": {"(True, True)": 623, "(False, True)": 2119, "(True, False)": 274, "(False, False)": 8850}, "roc": {"auc": 0.8124735433078716}}, "trained": 1443820963.5748563}
```

I had to modify ScorerModel in order to get this working.  This demonstrates that the utility still works for old scorer models. 
```
$ ./utility model_info ../ores-wikimedia-config/models/enwiki.reverted.linear_svc.model 
ScikitLearnClassifier
 - type: LinearSVC
 - version: 0.3.1
 - trained: 2015-09-02T20:24:12.202975

No stats available
```