### PR TITLE
Fixes model_info table format.

### DIFF
--- a/revscoring/scorer_models/scorer_model.py
+++ b/revscoring/scorer_models/scorer_model.py
@@ -321,11 +321,13 @@ class ScikitLearnClassifier(MLScorerModel):
 
             for actual in possible:
                 table_data.append(
-                    [actual] +
+                    [(str(actual))] +
                     [self.stats['table'].get((predicted, actual), 0)
                      for predicted in possible]
                 )
-            formatted.write(tabulate(table_data, headers=possible))
+            formatted.write(tabulate(
+                table_data,
+                headers=["~{0}".format(p) for p in possible]))
 
             return formatted.getvalue()
 


### PR DESCRIPTION
Used to look like:
```
ScikitLearnClassifier
 - type: LinearSVC
 - version: 0.0.2
 - trained: 2015-10-04T13:31:09.522182

Accuracy: 0.8763621123218777

ROC-AUC: 0.8985737255272871

      False    True
--  -------  ------
 0     9278      82
 1     2167     403
```

Not it looks like:
```
ScikitLearnClassifier
 - type: LinearSVC
 - version: 0.0.2
 - trained: 2015-10-04T13:31:09.522182

Accuracy: 0.8763621123218777

ROC-AUC: 0.8985737255272871

         ~False    ~True
-----  --------  -------
False      9278       82
True       2167      403
```
