### PR TITLE
Fixes recall_at_fpr metric and adds recall_at_precision.

### DIFF
--- a/revscoring/scorer_models/test_statistics/__init__.py
+++ b/revscoring/scorer_models/test_statistics/__init__.py
@@ -32,8 +32,10 @@ from .f1 import f1
 from .filter_rate_at_recall import filter_rate_at_recall
 from .precision_recall import precision_recall
 from .recall_at_fpr import recall_at_fpr
+from .recall_at_precision import recall_at_precision
 from .roc import roc
 from .table import table
 
 __all__ = [TestStatistic, ClassifierStatistic, accuracy, precision, recall, f1,
-           filter_rate_at_recall, precision_recall, recall_at_fpr, roc, table]
+           filter_rate_at_recall, precision_recall, recall_at_fpr,
+           recall_at_precision, roc, table]

--- a/revscoring/scorer_models/test_statistics/recall_at_precision.py
+++ b/revscoring/scorer_models/test_statistics/recall_at_precision.py
@@ -1,0 +1,99 @@
+import io
+from collections import defaultdict
+
+from sklearn.metrics import precision_score, recall_score
+from tabulate import tabulate
+
+from . import util
+from .test_statistic import ClassifierStatistic, TestStatistic
+
+
+class recall_at_precision(ClassifierStatistic):
+    """
+    Constructs a statistics generator that measures the maximum recall
+    that can be achieved at minimum precision.  As a classifier
+    gets better, the attainable recall at precision should increase.
+
+    When applied to a test set, the `score()` method will return a dictionary
+    with three fields:
+
+     * threshold: The probability threshold where recall was maximized
+     * recall: The recall at `threshold`
+     * precision: The precision at `threshold`
+
+    :Parameters:
+        min_precision : `float`
+            Minimum precision that will be tolerated
+    """
+    def __init__(self, min_precision):
+        self.min_precision = min_precision
+        super().__init__(min_precision=min_precision)
+
+    def _single_class_stat(self, scores, labels, comparison_label):
+        y_proba = [s['probability'][comparison_label] for s in scores]
+        y_true = [label == comparison_label for label in labels]
+
+        probas = set(y_proba)
+        proba_recall_precision = [
+            (proba, recall_score(y_true, [p >= proba for p in y_proba]),
+             precision_score(y_true, [p >= proba for p in y_proba]))
+            for proba in probas
+        ]
+        filtered = [(proba, recall, precision)
+                    for proba, recall, precision in proba_recall_precision
+                    if precision >= self.min_precision]
+
+        if len(filtered) == 0:
+            return {
+                'threshold': None,
+                'recall': None,
+                'precision': None
+            }
+        else:
+            filtered.sort(key=lambda v: v[1], reverse=True)
+            return dict(zip(['threshold', 'recall', 'precision'], filtered[0]))
+
+    def merge(self, stats):
+        label_vals = defaultdict(lambda: defaultdict(list))
+
+        for stat in stats:
+            for label, label_stat in stat.items():
+                label_vals[label]['threshold'].append(label_stat['threshold'])
+                label_vals[label]['recall'].append(label_stat['recall'])
+                label_vals[label]['precision'].append(label_stat['precision'])
+
+        merged_stats = {}
+        for label, metric_vals in label_vals.items():
+            merged_stats[label] = \
+                {name: util.mean_or_none(vals)
+                 for name, vals in metric_vals.items()}
+
+        return merged_stats
+
+    def format(self, stats, format="str"):
+        if format == "str":
+            return self.format_str(stats)
+        elif format == "json":
+            return util.round_floats(stats, 3)
+        else:
+            raise TypeError("Format '{0}' not available for {1}."
+                            .format(format, self.__name__))
+
+    def format_str(self, stat):
+        formatted = io.StringIO()
+        formatted.write("Recall @ {0} precision:\n"
+                        .format(self.min_precision))
+
+        table_data = [(repr(label),
+                       util.round_or_none(stat[label]['threshold'], 3),
+                       util.round_or_none(stat[label]['recall'], 3),
+                       util.round_or_none(stat[label]['precision'], 3))
+                      for label in sorted(stat.keys())]
+        table = tabulate(
+            table_data, headers=["label", "threshold", "recall", "precision"])
+        formatted.write("".join(["\t" + line + "\n" for line in
+                                 table.split("\n")]))
+
+        return formatted.getvalue()
+
+TestStatistic.register("recall_at_precision", recall_at_precision)

--- a/revscoring/scorer_models/test_statistics/tests/test_recall_at_precision.py
+++ b/revscoring/scorer_models/test_statistics/tests/test_recall_at_precision.py
@@ -1,0 +1,113 @@
+from nose.tools import eq_
+
+from ..recall_at_precision import recall_at_precision
+
+
+def test_boolean():
+    test_statistic = recall_at_precision(0.90)
+    score_labels = [
+        ({'probability': {True: 0.89, False: 0.11}},
+         {'probability': {True: 0.83, False: 0.17}}, True),
+        ({'probability': {True: 0.09, False: 0.91}},
+         {'probability': {True: 0.63, False: 0.37}}, False),
+        ({'probability': {True: 0.83, False: 0.17}},
+         {'probability': {True: 0.75, False: 0.25}}, True),
+        ({'probability': {True: 0.07, False: 0.93}},
+         {'probability': {True: 0.53, False: 0.47}}, False),
+        ({'probability': {True: 0.97, False: 0.03}},
+         {'probability': {True: 0.94, False: 0.06}}, True),
+        ({'probability': {True: 0.15, False: 0.85}},
+         {'probability': {True: 0.56, False: 0.44}}, False),
+        ({'probability': {True: 0.99, False: 0.01}},
+         {'probability': {True: 0.79, False: 0.21}}, True),
+        ({'probability': {True: 0.05, False: 0.95}},
+         {'probability': {True: 0.63, False: 0.37}}, False),
+        ({'probability': {True: 0.75, False: 0.25}},
+         {'probability': {True: 0.51, False: 0.49}}, True),
+        ({'probability': {True: 0.18, False: 0.82}},
+         {'probability': {True: 0.86, False: 0.24}}, False)
+    ]
+    all_right, half_right, labels = zip(*score_labels)
+
+    stats = test_statistic.score(all_right, labels)
+    eq_(stats[True]['threshold'], 0.75)
+    eq_(stats[True]['recall'], 1.0)
+
+    stats = test_statistic.score(half_right, labels)
+    eq_(stats[True]['threshold'], 0.94)
+    eq_(round(stats[True]['recall'], 3), 0.2)
+
+    eq_(test_statistic.format(stats),
+        "Recall @ 0.9 precision:\n" +
+        "\tlabel      threshold    recall    precision\n" +
+        "\t-------  -----------  --------  -----------\n" +
+        "\tFalse\n" +
+        "\tTrue            0.94       0.2            1\n")
+    eq_(test_statistic.format(stats, format="json"),
+        {True: {'recall': 0.2, 'threshold': 0.94, 'precision': 1.0},
+         False: {'recall': None, 'threshold': None, 'precision': None}})
+
+
+def test_multiclass():
+    test_statistic = recall_at_precision(0.90)
+    score_labels = [
+        ({'probability': {"a": 0.92, "b": 0.03, "c": 0.05}},
+         {'probability': {"a": 0.50, "b": 0.15, "c": 0.35}}, "a"),
+        ({'probability': {"a": 0.12, "b": 0.82, "c": 0.10}},
+         {'probability': {"a": 0.19, "b": 0.60, "c": 0.21}}, "b"),
+        ({'probability': {"a": 0.05, "b": 0.10, "c": 0.85}},
+         {'probability': {"a": 0.32, "b": 0.36, "c": 0.32}}, "c"),
+        ({'probability': {"a": 0.92, "b": 0.03, "c": 0.05}},
+         {'probability': {"a": 0.50, "b": 0.15, "c": 0.35}}, "a"),
+        ({'probability': {"a": 0.12, "b": 0.82, "c": 0.10}},
+         {'probability': {"a": 0.19, "b": 0.60, "c": 0.21}}, "b"),
+        ({'probability': {"a": 0.05, "b": 0.10, "c": 0.85}},
+         {'probability': {"a": 0.32, "b": 0.36, "c": 0.32}}, "c"),
+        ({'probability': {"a": 0.92, "b": 0.03, "c": 0.05}},
+         {'probability': {"a": 0.50, "b": 0.15, "c": 0.35}}, "a"),
+        ({'probability': {"a": 0.12, "b": 0.82, "c": 0.10}},
+         {'probability': {"a": 0.19, "b": 0.60, "c": 0.21}}, "b"),
+        ({'probability': {"a": 0.05, "b": 0.10, "c": 0.85}},
+         {'probability': {"a": 0.32, "b": 0.36, "c": 0.32}}, "c"),
+        ({'probability': {"a": 0.92, "b": 0.03, "c": 0.05}},
+         {'probability': {"a": 0.50, "b": 0.15, "c": 0.35}}, "a"),
+        ({'probability': {"a": 0.12, "b": 0.82, "c": 0.10}},
+         {'probability': {"a": 0.19, "b": 0.60, "c": 0.21}}, "b"),
+        ({'probability': {"a": 0.05, "b": 0.10, "c": 0.85}},
+         {'probability': {"a": 0.32, "b": 0.36, "c": 0.32}}, "c"),
+        ({'probability': {"a": 0.92, "b": 0.03, "c": 0.05}},
+         {'probability': {"a": 0.50, "b": 0.15, "c": 0.35}}, "a"),
+        ({'probability': {"a": 0.12, "b": 0.82, "c": 0.10}},
+         {'probability': {"a": 0.19, "b": 0.60, "c": 0.21}}, "b"),
+        ({'probability': {"a": 0.05, "b": 0.10, "c": 0.85}},
+         {'probability': {"a": 0.32, "b": 0.36, "c": 0.32}}, "c"),
+        ({'probability': {"a": 0.92, "b": 0.03, "c": 0.05}},
+         {'probability': {"a": 0.50, "b": 0.15, "c": 0.35}}, "a"),
+        ({'probability': {"a": 0.12, "b": 0.82, "c": 0.10}},
+         {'probability': {"a": 0.19, "b": 0.60, "c": 0.21}}, "b"),
+        ({'probability': {"a": 0.05, "b": 0.10, "c": 0.85}},
+         {'probability': {"a": 0.32, "b": 0.36, "c": 0.32}}, "c")
+    ]
+    all_right, sometimes_right, labels = zip(*score_labels)
+
+    stats = test_statistic.score(all_right, labels)
+    eq_(test_statistic.format(stats, format="json"),
+        {'a': {'threshold': 0.92, 'recall': 1.0, 'precision': 1.0},
+         'b': {'threshold': 0.82, 'recall': 1.0, 'precision': 1.0},
+         'c': {'threshold': 0.85, 'recall': 1.0, 'precision': 1.0}})
+
+    stats = test_statistic.score(sometimes_right, labels)
+    eq_(test_statistic.format(stats, format="json"),
+        {'a': {'threshold': 0.5, 'recall': 1.0, 'precision': 1.0},
+         'b': {'threshold': 0.6, 'recall': 1.0, 'precision': 1.0},
+         'c': {'threshold': None, 'recall': None, 'precision': None}})
+
+    assert len(test_statistic.format(stats)) > 5
+
+    merged_stats = test_statistic.merge(
+        [test_statistic.score(all_right, labels),
+         test_statistic.score(sometimes_right, labels)])
+    eq_(test_statistic.format(merged_stats, format="json"),
+        {'a': {'threshold': 0.71, 'recall': 1.0, 'precision': 1.0},
+         'b': {'threshold': 0.71, 'recall': 1.0, 'precision': 1.0},
+         'c': {'threshold': 0.85, 'recall': 1.0, 'precision': 1.0}})

--- a/revscoring/scorer_models/test_statistics/util.py
+++ b/revscoring/scorer_models/test_statistics/util.py
@@ -2,8 +2,8 @@ from statistics import mean
 
 
 def fpr_score(y_true, y_pred):
-    true_preds = sum(y_pred) or 1
-    return sum(yp and not yt for yt, yp in zip(y_true, y_pred)) / true_preds
+    false_obs = (len(y_true) - sum(y_true)) or 1
+    return sum(yp and not yt for yt, yp in zip(y_true, y_pred)) / false_obs
 
 
 def filter_rate_score(y_pred):


### PR DESCRIPTION
Addresses https://github.com/wiki-ai/revscoring/issues/292

Rather than FDR, we're measuring Precision.  `1-Precision = FDR`