### PR TITLE
Swap descriptions of features

### DIFF
--- a/ipython/feature_engineering.ipynb
+++ b/ipython/feature_engineering.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "source": [
     "## Extract features\n",
-    "The following line demonstrates a simple feature extraction.  We'll extract two features: `wikitext.revision.chars`, the number of characters added; and `wikitext.revision.diff.chars_added`, the number of characters in the entire revision.  Note that we wrap the call in a list() because it returns a generator.  "
+    "The following line demonstrates a simple feature extraction.  We'll extract two features: `wikitext.revision.chars`, the number of characters in the entire revision; and `wikitext.revision.diff.chars_added`, the number of characters added.  Note that we wrap the call in a list() because it returns a generator.  "
    ]
   },
   {


### PR DESCRIPTION
Corrected a typo in the Jupyter notebook by swapping the descriptions of features.

---

cc: @halfak @batpad