### PR TITLE
Bump pytz requirement to 2017.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ mwparserfromhell >= 0.3.3, < 0.4.999
 nltk >= 3.0.0, < 3.0.999
 nose >= 1.3.4, < 1.3.999
 numpy >= 1.8.2, < 1.10.999
-pytz == 2012c
+pytz == 2017.2
 requests >= 2.0.0, < 2.999.999
 setuptools >= 5.5.1, < 15.999
 pyenchant >= 1.6.6, < 1.6.999


### PR DESCRIPTION
Right now, revscoring errors out on me because of this