### PR TITLE
Limit memory usage of thresholds statistics

### DIFF
--- a/revscoring/scoring/models/sklearn.py
+++ b/revscoring/scoring/models/sklearn.py
@@ -132,9 +132,10 @@ class Classifier(model.Classifier):
 class ProbabilityClassifier(Classifier):
 
     def __init__(self, features, labels, statistics=None,
-                 population_rates=None, **kwargs):
+                 population_rates=None, threshold_ndigits=None, **kwargs):
         statistics = statistics if statistics is not None else Classification(
             labels, prediction_key="prediction", decision_key="probability",
+            threshold_ndigits=threshold_ndigits or 3,
             population_rates=population_rates)
         super().__init__(features, labels, statistics=statistics, **kwargs)
 

--- a/revscoring/scoring/statistics/classification/classification.py
+++ b/revscoring/scoring/statistics/classification/classification.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 class Classification(Statistics):
 
-    def __init__(self, labels, prediction_key="prediction", decision_key=None,
+    def __init__(self, labels, prediction_key="prediction",
+                 decision_key=None, threshold_ndigits=None,
                  population_rates=None, **kwargs):
         """
         Constructs a set of classification statistics
@@ -31,6 +32,9 @@ class Classification(Statistics):
             decision_key : `str`
                 A key into a score doc under which a scalar decision value
                 can be found for each potential class.
+            thresholds_ndigits : `int`
+                If set, round the threshold by this many decimals to compress
+                threshold statistics information.
             population_rates : `dict`
                 A mapping of label classes with float representing the rate
                 that each class occurs in the target population.  Rates
@@ -46,6 +50,7 @@ class Classification(Statistics):
         self.labels = labels
         self.prediction_key = prediction_key
         self.decision_key = decision_key
+        self.threshold_ndigits = threshold_ndigits
         self.population_rates = population_rates or {}
 
     def fit(self, score_labels):
@@ -104,6 +109,7 @@ class Classification(Statistics):
                 self.label_thresholds[label] = ScaledThresholdStatistics(
                     [s[self.decision_key][label] for s, l in score_labels],
                     [l == label for s, l in score_labels],
+                    threshold_ndigits=self.threshold_ndigits,
                     population_rate=self.population_rates.get(label))
 
             self['roc_auc'] = \

--- a/revscoring/scoring/statistics/classification/scaled_classification_matrix.py
+++ b/revscoring/scoring/statistics/classification/scaled_classification_matrix.py
@@ -5,6 +5,11 @@ logger = logging.getLogger(__name__)
 
 class ScaledClassificationMatrix:
 
+    __slots__ = ('tp', 'fp', 'tn', 'fn',
+                 'n', 'positives', 'negatives',
+                 'trues', 'falses', 'correct',
+                 'population_rate')
+
     def __init__(self, y_preds=None, y_trues=None,
                  counts=None, population_rate=None):
         """

--- a/revscoring/scoring/statistics/classification/scaled_threshold_statistics.py
+++ b/revscoring/scoring/statistics/classification/scaled_threshold_statistics.py
@@ -12,7 +12,8 @@ from .threshold_optimization import ThresholdOptimization
 class ScaledThresholdStatistics(list):
     FIELDS = ['roc_auc', 'pr_auc']
 
-    def __init__(self, y_decisions, y_trues, population_rate=None):
+    def __init__(self, y_decisions, y_trues, population_rate=None,
+                 threshold_ndigits=None):
         """
         Construct a sequence of ThresholdStatistics
 
@@ -27,6 +28,9 @@ class ScaledThresholdStatistics(list):
                 The rate at which the observed class appears in the population.
                 This value will be used to re-scale the number of y_trues
                 across all metrics.
+            threshold_ndigits : `int`
+                If set, round the threshold by this many decimals to compress
+                threshold statistics information.
         """  # noqa
         super().__init__()
         if population_rate is None:
@@ -35,6 +39,10 @@ class ScaledThresholdStatistics(list):
             n_true = sum(y_trues)
             observed_rate = n_true / len(y_trues)
             self.trues = sum(y_trues) * (population_rate / observed_rate)
+
+        if threshold_ndigits is not None:
+            y_decisions = [util.round(d, threshold_ndigits)
+                           for d in y_decisions]
         threshold_groups = groupby(
             sorted((y_d, y_t) for y_d, y_t in zip(y_decisions, y_trues)),
             key=lambda p: p[0])

--- a/revscoring/scoring/statistics/classification/scaled_threshold_statistics.py
+++ b/revscoring/scoring/statistics/classification/scaled_threshold_statistics.py
@@ -69,6 +69,8 @@ class ScaledThresholdStatistics(list):
         if field in self.FIELDS:
             method_name = field.replace("!", "_")
             return getattr(self, method_name)()
+        elif isinstance(field, int):
+            return super.__getitem__(field)
         else:
             if isinstance(field, ThresholdOptimization):
                 optimization = field

--- a/revscoring/scoring/statistics/classification/scaled_threshold_statistics.py
+++ b/revscoring/scoring/statistics/classification/scaled_threshold_statistics.py
@@ -58,10 +58,6 @@ class ScaledThresholdStatistics(list):
                 tn += not y_true
                 fn += y_true
 
-        sps = ScaledPredictionStatistics(
-            counts=(tp, fp, tn, fn), population_rate=population_rate)
-        self.append((threshold, sps))
-
     def roc_auc(self):
         return zero_to_one_auc([stat.fpr() for t, stat in self],
                                [stat.recall() for t, stat in self])

--- a/revscoring/scoring/statistics/classification/tests/test_scaled_threshold_statistics.py
+++ b/revscoring/scoring/statistics/classification/tests/test_scaled_threshold_statistics.py
@@ -82,3 +82,7 @@ def test_sts():
            abs(balanced_sts.roc_auc() - skewed_sts.roc_auc())
     assert abs(balanced_sts.pr_auc() - skewed_sts.pr_auc()) < 0.05, \
            abs(balanced_sts.pr_auc() - skewed_sts.pr_auc())
+
+    limited_skewed_sts = ScaledThresholdStatistics(
+        *zip(*SKEWED), population_rate=0.05, threshold_ndigits=1)
+    assert len(limited_skewed_sts) <= 11, len(limited_skewed_sts)


### PR DESCRIPTION
This PR contains changes that make it possible to limit threshold statistics by rounding the "decision" value that thresholds are based on.  This allows a user to effectively reduce the number of thresholds that are stored in revscoring.Model.info for probability based models.  

https://phabricator.wikimedia.org/T177544