### PR TITLE
Selectors: Count documents, labels per document instance, not per token

### DIFF
--- a/revscoring/datasources/meta/selectors.py
+++ b/revscoring/datasources/meta/selectors.py
@@ -54,13 +54,13 @@ class tfidf(Datasource):
         label_n = defaultdict(lambda: 0)
         for values, label in value_labels:
             table = values[0]
+            self.document_n += 1
+            label_n[label] += 1
             for term, freq in table.items():
                 if self.boolean:
                     freq = 1 if freq > 0 else -1
                 self.document_freq[term] += freq
-                self.document_n += 1
                 label_freq[label][term] += freq
-                label_n[label] += 1
 
         # Select terms
         if self.max_terms is not None:

--- a/revscoring/datasources/meta/tests/test_selectors.py
+++ b/revscoring/datasources/meta/tests/test_selectors.py
@@ -34,6 +34,7 @@ def test_tfidf():
     assert set(tfidf_table.keys()) == {'true', 'false', 'maybe'}
     assert tfidf_table['true'] > tfidf_table['false']
     assert tfidf_table['maybe'] > 0
+    assert my_tfidf_table.document_n == 9
 
     f = io.BytesIO()
     my_tfidf_table.dump(f)


### PR DESCRIPTION
Currently selectors counts document and label frequency in the inner loop iterating over tokens. This gives wrong values. Moved the counting to the outer loop which iterates over documents, thus giving correct document and label frequency.