### PR TITLE
Adds row formatting for long label names.

### DIFF
--- a/revscoring/scoring/statistics/classification/micro_macro_stats.py
+++ b/revscoring/scoring/statistics/classification/micro_macro_stats.py
@@ -7,6 +7,8 @@ from ...model_info import ModelInfo
 
 logger = logging.getLogger(__name__)
 
+MAX_COLUMNS_WIDTH_CHARS = 80
+
 
 class MicroMacroStats(ModelInfo):
 
@@ -52,10 +54,9 @@ class MicroMacroStats(ModelInfo):
             .format(self.field,
                     util.round(self['micro'], ndigits=ndigits),
                     util.round(self['macro'], ndigits=ndigits))
-        table_str = tabulate(
-            [[util.round(stat, ndigits)
-              for l, stat in self['labels'].items()]],
-            headers=self['labels'].keys())
+
+        table_str = self.format_label_table(ndigits)
+
         formatted += util.tab_it_in(table_str)
         return formatted
 
@@ -68,3 +69,22 @@ class MicroMacroStats(ModelInfo):
             'labels': {l: util.round(self['labels'][l], ndigits)
                        for l in self['labels']}
         }
+
+    def format_label_table(self, ndigits):
+        column_header_width = sum(max(len(str(l)) + 2, ndigits + 4)
+                                  for l in self['labels'])
+        if column_header_width < MAX_COLUMNS_WIDTH_CHARS:
+            return self.format_column_major_table(ndigits)
+        else:
+            return self.format_row_major_table(ndigits)
+
+    def format_row_major_table(self, ndigits):
+        return tabulate(
+            [[l, util.round(stat, ndigits)]
+              for l, stat in self['labels'].items()])
+
+    def format_column_major_table(self, ndigits):
+        return tabulate(
+            [[util.round(stat, ndigits)
+              for l, stat in self['labels'].items()]],
+            headers=self['labels'].keys())

--- a/revscoring/scoring/statistics/classification/micro_macro_stats.py
+++ b/revscoring/scoring/statistics/classification/micro_macro_stats.py
@@ -81,7 +81,7 @@ class MicroMacroStats(ModelInfo):
     def format_row_major_table(self, ndigits):
         return tabulate(
             [[l, util.round(stat, ndigits)]
-              for l, stat in self['labels'].items()])
+             for l, stat in self['labels'].items()])
 
     def format_column_major_table(self, ndigits):
         return tabulate(

--- a/revscoring/scoring/statistics/classification/tests/test_micro_macro_stats.py
+++ b/revscoring/scoring/statistics/classification/tests/test_micro_macro_stats.py
@@ -1,0 +1,32 @@
+import json
+
+from ..micro_macro_stats import MicroMacroStats
+from ..scaled_prediction_statistics import ScaledPredictionStatistics as SPS
+
+
+def test_micro_macro_stats():
+    # (tp, fp, tn, fn)
+    stats = {
+        'Short': SPS(counts=(10, 2, 5, 8)),
+        'Labels': SPS(counts=(9, 3, 9, 4)),
+        'Can': SPS(counts=(11, 1, 8, 5)),
+        'Be': SPS(counts=(10, 2, 9, 4)),
+        'Columns': SPS(counts=(5, 7, 3, 10))
+    }
+    mms = MicroMacroStats(stats, 'precision')
+
+    print(mms.format_str({}))
+    assert len(mms.format_str({}).split('\n')) <= 5
+
+    # (tp, fp, tn, fn)
+    stats = {
+        'A really long label name': SPS(counts=(10, 2, 5, 8)),
+        'Another long label name': SPS(counts=(9, 3, 9, 4)),
+        'Again we\'re very long': SPS(counts=(11, 1, 8, 5)),
+        'We should be too long': SPS(counts=(10, 2, 9, 4)),
+        'One more for good measure': SPS(counts=(5, 7, 3, 10))
+    }
+    mms = MicroMacroStats(stats, 'precision')
+
+    print(mms.format_str({}))
+    assert len(mms.format_str({}).split('\n')) > 5

--- a/revscoring/scoring/statistics/classification/tests/test_micro_macro_stats.py
+++ b/revscoring/scoring/statistics/classification/tests/test_micro_macro_stats.py
@@ -1,5 +1,3 @@
-import json
-
 from ..micro_macro_stats import MicroMacroStats
 from ..scaled_prediction_statistics import ScaledPredictionStatistics as SPS
 


### PR DESCRIPTION
when labels are short, string formatting looks like this:
```
precision (micro=0.754, macro=0.75):
	  Short    Labels     Be    Columns    Can
	-------  --------  -----  ---------  -----
	  0.833      0.75  0.833      0.417  0.917
```

when labels are long, string formatting looks like this:
```
precision (micro=0.754, macro=0.75):
	-------------------------  -----
	We should be too long      0.833
	Again we're very long      0.917
	A really long label name   0.833
	One more for good measure  0.417
	Another long label name    0.75
	-------------------------  -----
```