### PR TITLE
Revscoring: Implement fast scoring for fast cross validation

### DIFF
--- a/revscoring/scoring/models/model.py
+++ b/revscoring/scoring/models/model.py
@@ -246,8 +246,9 @@ class Learned(Model):
         logger.debug("Training cross-validation for {0}...".format(i + 1))
         model.train(train_set)
         logger.debug("Scoring cross-validation for {0}...".format(i + 1))
-        return [(model.score(feature_values), label)
-                for feature_values, label in test_set]
+        feature_values, labels = map(list, zip(*test_set))
+        docs = model.score_many(feature_values)
+        return list(zip(docs, labels))
 
 
 class Classifier(Learned):


### PR DESCRIPTION
- Implements a new method `score_many` in sklearn.py to score a bunch of instances together to utilize numpy's underlying optimizations of matrix multiplication.
- `_cross_score` is made to call this new method to improve speeds of cross_validation. The original score method is preserved for use in ORES.
- New tests added for `score` and `score_many` as well as a test for probability classifier in test_sklearn to improve coverage.