### PR TITLE
Fix a bug in load_kv and add tests for the same

### DIFF
--- a/revscoring/datasources/meta/tests/test_vectorizers.py
+++ b/revscoring/datasources/meta/tests/test_vectorizers.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+import pytest
 
 from revscoring.datasources import revision_oriented as ro
 from revscoring.dependencies import solve
@@ -16,3 +18,19 @@ def test_word2vec():
     vector = solve(wv, cache={ro.revision.text: 'a bv c d'})
     assert len(vector) == 4
     assert len(vector[0]) == 300
+
+
+@patch('gensim.models.keyedvectors')
+def test_loadkv_path(kv):
+    kv.KeyedVectors.load_word2vec_format.return_value = test_vectors
+    vectorizers.KeyedVectors = kv.KeyedVectors
+    vectors = vectorizers.word2vec.load_kv(path='foo')
+    assert vectors is not None
+
+
+@patch('gensim.models.keyedvectors')
+def test_loadkv_filename_none(kv):
+    kv.KeyedVectors.load_word2vec_format.side_effect = FileNotFoundError
+    vectorizers.KeyedVectors = kv.KeyedVectors
+    assert pytest.raises(FileNotFoundError,
+                         vectorizers.word2vec.load_kv, filename='foo')

--- a/revscoring/datasources/meta/vectorizers.py
+++ b/revscoring/datasources/meta/vectorizers.py
@@ -46,11 +46,15 @@ class word2vec(Datasource):
         elif filename is not None:
             for dir_path in ASSET_SEARCH_DIRS:
                 try:
-                    path = os.join(dir_path, filename)
+                    path = os.path.join(dir_path, filename)
                     return KeyedVectors.load_word2vec_format(
                         path, binary=True, limit=limit)
                 except FileNotFoundError:
                     continue
+            raise FileNotFoundError("Please make sure that 'filename' \
+                                    specifies the word vector binary name \
+                                    in default search paths or 'path' \
+                                    speficies file path of the binary")
         else:
             raise TypeError(
                 "load_kv() requires either 'filename' or 'path' to be set.")

--- a/revscoring/languages/english_vectors.py
+++ b/revscoring/languages/english_vectors.py
@@ -1,0 +1,4 @@
+from revscoring.datasources.meta import vectorizers
+
+google_news_kvs = \
+vectorizers.word2vec.load_kv(path='GoogleNews-vectors-negative300.bin.gz', limit=150000)

--- a/revscoring/languages/english_vectors.py
+++ b/revscoring/languages/english_vectors.py
@@ -1,4 +1,4 @@
 from revscoring.datasources.meta import vectorizers
 
-google_news_kvs = \
-vectorizers.word2vec.load_kv(path='GoogleNews-vectors-negative300.bin.gz', limit=150000)
+google_news_kvs = vectorizers.word2vec.load_kv(
+    path='GoogleNews-vectors-negative300.bin.gz', limit=150000)


### PR DESCRIPTION
* Changes os.join to os.path.join in vectorizers.word2vec.load_kv.
* Also adds tests for the load_kv method with different arguments
* Adds a module `english_vectors` to `revscoring.languages` to define Google News word vectors for
english which can be imported in consumer moduels.
This definition is mainly for optimization purposes so that scripts that
use multiprocessing don't replicate the large word vectors in each
child thread.
* Avoids adding google_news vectors to english.py to avoid loading the huge vectors every time other features of the module like stopwords are required.