### PR TITLE
Use global vectors for better multiprocessing and remove english_vectors

### DIFF
--- a/revscoring/datasources/meta/tests/test_vectorizers.py
+++ b/revscoring/datasources/meta/tests/test_vectorizers.py
@@ -1,6 +1,7 @@
+import pickle
 from unittest.mock import patch
-import pytest
 
+import pytest
 from revscoring.datasources import revision_oriented as ro
 from revscoring.dependencies import solve
 from revscoring.features import wikitext
@@ -12,12 +13,18 @@ test_vectors = {'a': [1] * 300,
                 'c': [1] * 300}
 
 
+def vectorize_words(words):
+    return vectorizers.word2vec.vectorize_words(test_vectors, words)
+
+
 def test_word2vec():
     wv = vectorizers.word2vec(wikitext.revision.datasources.words,
-                              test_vectors, name='word vectors')
+                              vectorize_words, name='word vectors')
     vector = solve(wv, cache={ro.revision.text: 'a bv c d'})
     assert len(vector) == 4
     assert len(vector[0]) == 300
+
+    assert pickle.loads(pickle.dumps(wv)) == wv
 
 
 @patch('gensim.models.keyedvectors')

--- a/revscoring/datasources/meta/vectorizers.py
+++ b/revscoring/datasources/meta/vectorizers.py
@@ -12,8 +12,8 @@ from ..datasource import Datasource
 
 ASSET_SEARCH_DIRS = ["word2vec/", "~/.word2vec/", "/var/share/word2vec/"]
 VECTOR_DIMENSIONS = 300
-
 keyed_vecs = {}
+
 
 class word2vec(Datasource):
     """

--- a/revscoring/datasources/meta/vectorizers.py
+++ b/revscoring/datasources/meta/vectorizers.py
@@ -12,7 +12,6 @@ from ..datasource import Datasource
 
 ASSET_SEARCH_DIRS = ["word2vec/", "~/.word2vec/", "/var/share/word2vec/"]
 VECTOR_DIMENSIONS = 300
-keyed_vecs = {}
 
 
 class word2vec(Datasource):
@@ -21,22 +20,24 @@ class word2vec(Datasource):
     datasource.
 
     :Parameters:
-        items_datasource : :class:`revscoring.Datasource`
+        words_datasource : :class:`revscoring.Datasource`
             A datasource that returns a list of words.
-        keyed_vectors : :class:`gensim.models.keyedvectors.KeyedVectors`
-            loaded key-vectors.  See :func:`~revscoring.datasources.meta.vectorizers.word2vec.load_kv`
+        vectorize_words : `function`
+            a function that takes a list of words and converts it to a list
+            of vectors of those words
         name : `str`
             A name for the `revscoring.FeatureVector`
     """  # noqa
 
-    def __init__(self, items_datasource, keyed_vectors, name=None):
-        name = self._format_name(name, [items_datasource, keyed_vectors])
-        keyed_vecs[name] = keyed_vectors
-        super().__init__(name, self.process, depends_on=[items_datasource])
+    def __init__(self, words_datasource, vectorize_words, name=None):
+        name = self._format_name(name, [words_datasource, vectorize_words])
 
-    def process(self, words):
-        return [keyed_vecs[self.name][word] if word in
-                keyed_vecs[self.name] else [0] * VECTOR_DIMENSIONS
+        super().__init__(name, vectorize_words, depends_on=[words_datasource])
+
+    @staticmethod
+    def vectorize_words(keyed_vectors, words):
+        return [keyed_vectors[word] if word in
+                keyed_vectors else [0] * VECTOR_DIMENSIONS
                 for word in words]
 
     @staticmethod

--- a/revscoring/datasources/meta/vectorizers.py
+++ b/revscoring/datasources/meta/vectorizers.py
@@ -13,6 +13,7 @@ from ..datasource import Datasource
 ASSET_SEARCH_DIRS = ["word2vec/", "~/.word2vec/", "/var/share/word2vec/"]
 VECTOR_DIMENSIONS = 300
 
+keyed_vecs = {}
 
 class word2vec(Datasource):
     """
@@ -30,12 +31,12 @@ class word2vec(Datasource):
 
     def __init__(self, items_datasource, keyed_vectors, name=None):
         name = self._format_name(name, [items_datasource, keyed_vectors])
-        self.keyed_vectors = keyed_vectors
+        keyed_vecs[name] = keyed_vectors
         super().__init__(name, self.process, depends_on=[items_datasource])
 
     def process(self, words):
-        return [self.keyed_vectors[word] if word in self.keyed_vectors
-                else [0] * VECTOR_DIMENSIONS
+        return [keyed_vecs[self.name][word] if word in
+                keyed_vecs[self.name] else [0] * VECTOR_DIMENSIONS
                 for word in words]
 
     @staticmethod

--- a/revscoring/languages/english_vectors.py
+++ b/revscoring/languages/english_vectors.py
@@ -1,4 +1,0 @@
-from revscoring.datasources.meta import vectorizers
-
-google_news_kvs = vectorizers.word2vec.load_kv(
-    filename='GoogleNews-vectors-negative300.bin.gz', limit=150000)

--- a/revscoring/languages/english_vectors.py
+++ b/revscoring/languages/english_vectors.py
@@ -1,4 +1,4 @@
 from revscoring.datasources.meta import vectorizers
 
 google_news_kvs = vectorizers.word2vec.load_kv(
-    path='GoogleNews-vectors-negative300.bin.gz', limit=150000)
+    filename='GoogleNews-vectors-negative300.bin.gz', limit=150000)


### PR DESCRIPTION
* Experiments have shown that using global vectors in the vectorizers file works better for memory sharing - https://phabricator.wikimedia.org/T189364
* Removes the english_vectors script since we no longer need the vectors as a separate module.
